### PR TITLE
商品出品機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'devise'
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.5)
       activesupport (= 6.0.3.5)
       globalid (>= 0.3.6)
@@ -98,6 +100,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     listen (3.1.5)
@@ -113,6 +118,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -201,6 +207,8 @@ GEM
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -263,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
@@ -270,8 +279,10 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gimei
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   puma (~> 3.11)
   rails (~> 6.0.0)

--- a/app/assets/stylesheets/items/exhibit-btn.css
+++ b/app/assets/stylesheets/items/exhibit-btn.css
@@ -1,0 +1,22 @@
+.purchase-btn {
+  width: 120px;
+  background: #3ccace;
+  text-align: center;
+  border-radius: 4%;
+  bottom: 32px;
+  right: 32px;
+  position: fixed;
+  padding: 15px;
+}
+
+.purchase-btn-text {
+  color: #fff;
+  display: block;
+  font-size: 18px;
+  text-decoration: none;
+  margin-bottom: 5px;
+}
+
+.purchase-btn-icon {
+  width: 60%;
+}

--- a/app/assets/stylesheets/items/new.css
+++ b/app/assets/stylesheets/items/new.css
@@ -1,0 +1,229 @@
+/* border-bottom: 1px solid #eee; */
+
+
+.items-sell-contents {
+  background-color: #f5f5f5;
+  font-family: "Source Sans Pro", Helvetica, Arial, "æ¸¸ã‚´ã‚·ãƒƒã‚¯ä½“", "YuGothic", "ãƒ¡ã‚¤ãƒªã‚ª", "Meiryo", sans-serif;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  min-width: 500px;
+}
+
+.items-sell-header {
+  padding: 5vh 0;
+  text-align: center;
+}
+
+.items-sell-main {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 450px;
+  padding: 10vh 15vw;
+}
+
+.items-sell-title {
+  font-size: 22px;
+  font-weight: bold;
+  text-align: center;
+}
+
+/* 共通 */
+.indispensable {
+  background: #ea352d;
+  margin-left: 8px;
+  padding: 3px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.weight-bold-text {
+  font-weight: bold;
+  min-width: 170px;
+  margin-bottom: 10px;
+}
+
+.select-box {
+  height: 30px;
+  width: 100%;
+  background-color: #f5f5f5;
+  padding-left: 20px;
+}
+
+.question {
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  background: #0099e8;
+  color: #FFF;
+  font-size: 13px;
+  text-align: center;
+  line-height: 20px;
+  text-decoration: none;
+  margin-left: 5px;
+}
+
+.question-text {
+  display: flex;
+}
+
+/* /共通 */
+
+/* 出品画像 */
+.img-upload {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding: 2vh 0;
+}
+
+.click-upload {
+  margin: 15px 0;
+  min-width: 250px;
+}
+
+.click-upload>p {
+  margin-bottom: 15px;
+}
+
+/* /出品画像 */
+
+/* 商品名と商品説明 */
+.new-items {
+  padding: 2vh 0;
+}
+
+.items-text {
+  width: 100%;
+  padding: 16px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  resize: none;
+}
+
+.items-explain {
+  margin-top: 2vh;
+}
+
+/* /商品名と商品説明 */
+
+/* 商品の詳細など */
+.items-detail {
+  display: flex;
+  justify-content: space-between;
+  padding: 2vh 0;
+}
+
+.items-detail>.form {
+  width: 300px;
+  padding: 2vh 0;
+}
+
+.select-box {
+  margin: 2vh 0;
+}
+
+/* /商品の詳細など */
+
+/* 販売価格 */
+.sell-price {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.price-content {
+  width: 300px;
+  border-bottom: 1px solid #ccc;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.price-text {
+  /* min-width: 170px; */
+  display: flex;
+  align-items: center;
+}
+
+.sell-yen {
+  font-size: 18px;
+}
+
+.price-input {
+  height: 30px;
+  text-align: right;
+  padding-right: 10px;
+}
+
+/* /販売価格 */
+
+/* 注意書き */
+.caution {
+  padding: 5vh 0;
+}
+
+.sentence>a {
+  color: #0099e8;
+  text-decoration: none;
+}
+
+/* /注意書き */
+
+/* 下部ボタン */
+.sell-btn-contents {
+  width: 100%;
+  text-align: center;
+}
+
+.sell-btn {
+  background: #ea352d;
+  border: 1px solid #ea352d;
+  color: #fff;
+  width: 100%;
+  height: 50px;
+  font-size: 14px;
+  margin-bottom: 4vh;
+}
+
+.back-btn {
+  background: #aaa;
+  border: 1px solid #aaa;
+  color: #fff;
+  padding: 15px 35%;
+  text-decoration: none;
+}
+
+/* /下部ボタン */
+
+.items-sell-footer {
+  background-color: #f5f5f5;
+  width: 60vw;
+  padding: 3ch 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+
+.items-sell-footer>.menu {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 3vh 0;
+}
+
+.menu>li>a {
+  color: black;
+  font-size: 12px;
+  margin: 2vw;
+}
+
+.inc {
+  font-size: 13px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!, only: :new
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
@@ -6,12 +7,13 @@ class ApplicationController < ActionController::Base
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]  # 環境変数を読み込む記述に変更
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']  # 環境変数を読み込む記述に変更
     end
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :family_name, :first_name_kana, :family_name_kana, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :first_name, :family_name, :first_name_kana, :family_name_kana,
+                                             :birthday])
   end
-
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!, only: :new
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,27 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: :new
+
   def index
+    @item = Item.all
+  end
+
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:image, :name, :description, :category_id, :status_id, :delivery_fee_id, :area_id, :day_id,
+                                 :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
 
   def index
-    @item = Item.all
+    # @item = Item.all
   end
 
   def new

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,7 @@ require("@rails/ujs").start()
 
 require("@rails/activestorage").start()
 require("channels")
-
+require("packs/item_new");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/item_new.js
+++ b/app/javascript/packs/item_new.js
@@ -1,0 +1,18 @@
+window.addEventListener("load",()=>{
+
+  const priceInput = document.getElementById("item-price");
+  priceInput.addEventListener("input", () => {
+    const inputValue = priceInput.value;
+    console.log(inputValue);
+
+    const addTaxDom = document.getElementById("add-tax-price")
+    addTaxDom.innerHTML = (Math.floor(inputValue * 0.1));
+     console.log(addTaxDom);
+
+     const profitNumber = document.getElementById("profit")
+     const value_result = inputValue * 0.1
+     console.log(value_result)
+     profitNumber.innerHTML = (Math.floor(inputValue - value_result));
+       console.log(profitNumber);
+  })
+})

--- a/app/javascript/packs/item_new.js
+++ b/app/javascript/packs/item_new.js
@@ -3,7 +3,6 @@ window.addEventListener("load",()=>{
   const priceInput = document.getElementById("item-price");
   priceInput.addEventListener("input", () => {
     const inputValue = priceInput.value;
-    console.log(inputValue);
 
     const addTaxDom = document.getElementById("add-tax-price")
     addTaxDom.innerHTML = (Math.floor(inputValue * 0.1));

--- a/app/javascript/packs/item_new.js
+++ b/app/javascript/packs/item_new.js
@@ -7,12 +7,10 @@ window.addEventListener("load",()=>{
 
     const addTaxDom = document.getElementById("add-tax-price")
     addTaxDom.innerHTML = (Math.floor(inputValue * 0.1));
-     console.log(addTaxDom);
 
      const profitNumber = document.getElementById("profit")
      const value_result = inputValue * 0.1
-     console.log(value_result)
+    
      profitNumber.innerHTML = (Math.floor(inputValue - value_result));
-       console.log(profitNumber);
   })
 })

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,0 +1,23 @@
+class Area < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
+    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' },
+    { id: 7, name: '山形県' }, { id: 8, name: '福島県' }, { id: 9, name: '茨城県' },
+    { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' },
+    { id: 16, name: '新潟県' }, { id: 17, name: '富山県' }, { id: 18, name: '石川県' },
+    { id: 19, name: '福井県' }, { id: 20, name: '山梨県' }, { id: 21, name: '長野県' },
+    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' },
+    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' },
+    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' },
+    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
+    { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,18 @@
+class Category < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: 'レディース' },
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
+    { id: 5, name: 'インテリア・住まい・小物' },
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ホビー・グッズ' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,0 +1,11 @@
+class Day < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '1~2日で発送' },
+    { id: 3, name: '2~3日で発送' },
+    { id: 4, name: '4~7日で発送' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,0 +1,10 @@
+class DeliveryFee < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '着払い(購入者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,25 @@
+class Item < ApplicationRecord
+  belongs_to :user
+  has_one_attached :image
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :status
+  belongs_to :delivery_fee
+  belongs_to :area
+  belongs_to :day
+
+  with_options presence: true do
+    validates :name
+    validates :description
+    validates :image
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than: 9_999_999 }
+  end
+
+  with_options numericality: { other_than: 1 } do
+    validates :category_id
+    validates :status_id
+    validates :delivery_fee_id
+    validates :area_id
+    validates :day_id
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,14 @@
+class Status < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '新品、未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' },
+    { id: 7, name: '全体的に状態が悪い' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates  :password,:password_confirmation, format: { with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i }
+  validates :password, :password_confirmation, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }
   with_options presence: true do
     validates :nickname
 
@@ -19,8 +19,7 @@ class User < ApplicationRecord
     end
 
     validates :birthday
-
   end
 
-    
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -180,7 +180,7 @@
   </div>
   <%# /商品一覧 %>
 </div>
-<%= link_to('#', class: 'purchase-btn') do %>
+<%= link_to( new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,157 @@
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with model: @item, local: true do |f| %>
+
+    <%= render 'devise/shared/error_messages', model: f.object %>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+        </div>
+        </span>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "出品する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
+  resources :items, only: [:index, :new, :create]
 end

--- a/db/migrate/20210222114628_create_items.rb
+++ b/db/migrate/20210222114628_create_items.rb
@@ -1,0 +1,17 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+
+      t.string :name             null: false
+      t.text :description        null: false
+      t.integer :category_id     null: false
+      t.integer :status_id       null: false
+      t.integer :delivery_fee_id null: false
+      t.integer :area_id         null: false
+      t.integer :day_id          null: false
+      t.integer :price           null: false
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210222123756_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210222123756_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_140646) do
+ActiveRecord::Schema.define(version: 2021_02_22_123756) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "category_id"
+    t.integer "status_id"
+    t.integer "delivery_fee_id"
+    t.integer "area_id"
+    t.integer "day_id"
+    t.integer "price"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
@@ -30,4 +66,6 @@ ActiveRecord::Schema.define(version: 2021_02_18_140646) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "items", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :item do
+    name            { 'test' }
+    description     { 'test' }
+    category_id     { '2' }
+    status_id       { '2' }
+    delivery_fee_id { '2' }
+    area_id         { '2' }
+    day_id          { '2' }
+    price           { '500' }
+    association :user
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :item do
     name            { 'test' }
     description     { 'test' }
-    category_id     { '2' }
-    status_id       { '2' }
-    delivery_fee_id { '2' }
-    area_id         { '2' }
-    day_id          { '2' }
-    price           { '500' }
+    category_id     { 2 }
+    status_id       { 2 }
+    delivery_fee_id { 2 }
+    area_id         { 2 }
+    day_id          { 2 }
+    price           { 500 }
     association :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :user do
-    nickname              {"test"}
-    email                 {Faker::Internet.free_email}
+    nickname              { 'test' }
+    email                 { Faker::Internet.free_email }
     password = Faker::Internet.password(min_length: 6)
-    password {password}
-    password_confirmation {password}
-    first_name            {"太郎"}
-    family_name           {"山田"}
-    first_name_kana       {"タロウ"}
-    family_name_kana      {"ヤマダ"}
-    birthday              {"2000-02-22"}
+    password { password }
+    password_confirmation { password }
+    first_name            { '太郎' }
+    family_name           { '山田' }
+    first_name_kana       { 'タロウ' }
+    family_name_kana      { 'ヤマダ' }
+    birthday              { '2000-02-22' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  before do
+    @item = FactoryBot.build(:item)
+    @item.image = fixture_file_upload('app/assets/images/item-sample.png')
+  end
+
+  describe '商品出品機能' do
+    context '商品が出品できる場合' do
+      it '必要な情報を適切に入力すると保存できる' do
+        expect(@item).to be_valid
+      end
+    end
+
+    context '商品が出品できない場合' do
+      it '商品画像がなければ保存できない' do
+        @item.image = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Image can't be blank")
+      end
+
+      it '商品名がなければ保存できない' do
+        @item.name = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Name can't be blank")
+      end
+
+      it '商品説明がなければ保存できない' do
+        @item.description = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Description can't be blank")
+      end
+      it 'カテゴリーが未選択だと保存できない' do
+        @item.category_id = '0'
+        @item.valid?
+        expect(@item.errors.full_messages).to include
+      end
+      it '商品状態が未選択だと保存できない' do
+        @item.status_id = '0'
+        @item.valid?
+        expect(@item.errors.full_messages).to include
+      end
+
+      it '配送料負担が未選択だと保存できない' do
+        @item.delivery_fee_id = '0'
+        @item.valid?
+        expect(@item.errors.full_messages).to include
+      end
+
+      it '発送元地域が未選択だと保存できない' do
+        @item.area_id = '0'
+        @item.valid?
+        expect(@item.errors.full_messages).to include
+      end
+
+      it '発送までの日数が未選択だと保存できない' do
+        @item.day_id = '0'
+        @item.valid?
+        expect(@item.errors.full_messages).to include
+      end
+
+      it '販売価格の情報がないと保存できない' do
+        @item.price = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Price can't be blank")
+      end
+
+      it '販売価格は、¥300~¥9,999,999以外は保存できない' do
+        @item.price = '100'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
+      end
+
+      it '販売価格は半角英数字以外は保存できない' do
+        @item.price = '１２３'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe Item, type: :model do
       end
 
       it '販売価格は、¥300~¥9,999,999以外は保存できない' do
-        @item.price = 100
+        @item.price = 299
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
 
       it '販売価格は、¥300~¥9,999,999以外は保存できない' do
-        @item.price = 99999999
+        @item.price = 10000000
         @item.valid?
         expect(@item.errors.full_messages).to include("Price must be less than 9999999")
       end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,30 +32,30 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Description can't be blank")
       end
       it 'カテゴリーが未選択だと保存できない' do
-        @item.category_id = '0'
+        @item.category_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include
       end
       it '商品状態が未選択だと保存できない' do
-        @item.status_id = '0'
+        @item.status_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include
       end
 
       it '配送料負担が未選択だと保存できない' do
-        @item.delivery_fee_id = '0'
+        @item.delivery_fee_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include
       end
 
       it '発送元地域が未選択だと保存できない' do
-        @item.area_id = '0'
+        @item.area_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include
       end
 
       it '発送までの日数が未選択だと保存できない' do
-        @item.day_id = '0'
+        @item.day_id = 0
         @item.valid?
         expect(@item.errors.full_messages).to include
       end
@@ -67,13 +67,31 @@ RSpec.describe Item, type: :model do
       end
 
       it '販売価格は、¥300~¥9,999,999以外は保存できない' do
-        @item.price = '100'
+        @item.price = 100
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
 
-      it '販売価格は半角英数字以外は保存できない' do
+      it '販売価格は、¥300~¥9,999,999以外は保存できない' do
+        @item.price = 99999999
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Price must be less than 9999999")
+      end
+
+      it '販売価格は半角数字以外は保存できない' do
         @item.price = '１２３'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+
+      it '販売価格は半角英数混合では保存できない' do
+        @item.price = 'aaa111'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is not a number')
+      end
+
+      it '販売価格は半角英語では保存できない' do
+        @item.price = 'aaa'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not a number')
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,20 +7,19 @@ RSpec.describe User, type: :model do
 
   describe 'ユーザー新規登録' do
     context '新規登録できない時' do
-
-      it "nicknameが空では登録できない" do
+      it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Nickname can't be blank")
       end
 
-      it "emailが空では登録できない" do
+      it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Email can't be blank")
       end
 
-      it "重複したemailが存在する場合登録できない" do
+      it '重複したemailが存在する場合登録できない' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.email = @user.email
@@ -28,13 +27,13 @@ RSpec.describe User, type: :model do
         expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
 
-      it "emailは@を含まないと登録できない" do
+      it 'emailは@を含まないと登録できない' do
         @user.email = 'test.com'
         @user.valid?
         expect(@user.errors.full_messages).to include('Email is invalid')
       end
 
-      it "passwordが空では登録できない" do
+      it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Password can't be blank")
@@ -56,7 +55,7 @@ RSpec.describe User, type: :model do
       it 'passwordは全角のみでは登録できないこと' do
         @user.password = 'ああああああ'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password is invalid")
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", 'Password is invalid')
       end
 
       it 'passwordとpassword_confirmationが不一致では登録できないこと' do
@@ -66,65 +65,63 @@ RSpec.describe User, type: :model do
         expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
       end
 
-      it "first_nameが空では登録できないこと" do
+      it 'first_nameが空では登録できないこと' do
         @user.first_name = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("First name can't be blank")
       end
 
-      it "first_nameが全角(漢字・ひらがな・カタカナ)以外では登録できないこと" do
-        @user.first_name = "kana"
+      it 'first_nameが全角(漢字・ひらがな・カタカナ)以外では登録できないこと' do
+        @user.first_name = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name is invalid")
+        expect(@user.errors.full_messages).to include('First name is invalid')
       end
 
-      it "family_nameが空では登録できないこと" do
+      it 'family_nameが空では登録できないこと' do
         @user.family_name = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Family name can't be blank")
       end
 
-      it "family_nameが全角(漢字・ひらがな・カタカナ)以外では登録できないこと" do
-        @user.family_name = "kana"
+      it 'family_nameが全角(漢字・ひらがな・カタカナ)以外では登録できないこと' do
+        @user.family_name = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Family name is invalid")
+        expect(@user.errors.full_messages).to include('Family name is invalid')
       end
 
-      it "first_name_kanaが空では登録できないこと" do
+      it 'first_name_kanaが空では登録できないこと' do
         @user.first_name_kana = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("First name kana can't be blank")
       end
 
-      it "first_name_kanaが全角(カタカナ)以外では登録できないこと" do
-        @user.first_name_kana = "kana"
+      it 'first_name_kanaが全角(カタカナ)以外では登録できないこと' do
+        @user.first_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana is invalid")
+        expect(@user.errors.full_messages).to include('First name kana is invalid')
       end
 
-      it "family_name_kanaが空では登録できないこと" do
+      it 'family_name_kanaが空では登録できないこと' do
         @user.family_name_kana = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Family name kana can't be blank")
       end
 
-      it "family_name_kanaが全角(カタカナ)以外では登録できないこと" do
-        @user.family_name_kana = "kana"
+      it 'family_name_kanaが全角(カタカナ)以外では登録できないこと' do
+        @user.family_name_kana = 'kana'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Family name kana is invalid")
+        expect(@user.errors.full_messages).to include('Family name kana is invalid')
       end
 
-      it "birthdayが空では登録できないこと" do
+      it 'birthdayが空では登録できないこと' do
         @user.birthday = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Birthday can't be blank")
       end
-
     end
 
     context '新規登録できるとき' do
-
-      it "nicknameとemail、passwordとpassword_confirmation、first_name、family_name、first_name_kana、family_name_kana、birthdayが存在すれば登録できること" do
+      it 'nicknameとemail、passwordとpassword_confirmation、first_name、family_name、first_name_kana、family_name_kana、birthdayが存在すれば登録できること' do
         expect(@user).to be_valid
       end
 
@@ -134,27 +131,25 @@ RSpec.describe User, type: :model do
         expect(@user).to be_valid
       end
 
-      it "first_nameが全角であれば登録できること" do
+      it 'first_nameが全角であれば登録できること' do
         @user.first_name = '全角かナ'
         expect(@user).to be_valid
       end
 
-      it "family_nameが全角では登録であれば登録できること" do
+      it 'family_nameが全角では登録であれば登録できること' do
         @user.family_name = '全角かナ'
         expect(@user).to be_valid
       end
 
-      it "first_name_kanaが全角カナであれば登録できること" do
+      it 'first_name_kanaが全角カナであれば登録できること' do
         @user.first_name_kana = 'カナ'
         expect(@user).to be_valid
       end
 
-      it "family_name_kanaが全角カナであれば登録できること" do
+      it 'family_name_kanaが全角カナであれば登録できること' do
         @user.family_name_kana = 'カナ'
         expect(@user).to be_valid
       end
-
     end
-
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-I18n.locale = "en"
+I18n.locale = 'en'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get items_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
# What
商品出品機能を作成
# Why
フリマアプリにて商品出品を再現するため

- ログイン状態のユーザーは、商品出品ページへ遷移できる動画
https://gyazo.com/cdcfd0aa6e5dea0ea13d8a2b1dbc2747

- 金額が入力されると同時に、販売手数料と販売利益が表示される動画 
https://gyazo.com/657a6a5b8b83bf308b292e3499e57811

- 正しく情報を記入すると、商品を出品できる動画
https://gyazo.com/9bf3d10358518df6cabac9b479e2cb4f

- 入力に問題のある状態では商品は出品できず、エラーメッセージが出力される動画
https://gyazo.com/cb74aa7bb5a1ab22936747aa3cce18b9

- ログアウト状態のユーザーは、商品出品ページへ遷移しようとすると、ログインページへ遷移する動画
https://gyazo.com/4d4805ea5785ea826269cbe9e1d58996

- テスト結果の画像
https://gyazo.com/528dba825a11507175dd427eb4c4b907

